### PR TITLE
Use absolute path to get ROOT

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -66,7 +66,7 @@ if DEVMODE:
                          filename=__file__, lineno=0,
                          line=f"PCAPKIT_DEVMODE={os.environ['PCAPKIT_DEVMODE']}")
 else:
-    ROOT = os.path.dirname(os.path.relpath(__file__))
+    ROOT = os.path.dirname(os.path.abspath(__file__))
     tbtrim.set_trim_rule(lambda filename: ROOT in os.path.realpath(filename),
                          exception=BaseError, strict=False)
 


### PR DESCRIPTION
```py
Traceback (most recent call last):
  File ".\extractor.py", line 9, in <module>
    import pcapkit
  File "C:\Users\koyo\AppData\Local\Programs\Python\Python37\lib\site-packages\pcapkit\__init__.py", line 63, in <module>
    ROOT = os.path.dirname(os.path.relpath(__file__))
  File "C:\Users\koyo\AppData\Local\Programs\Python\Python37\lib\ntpath.py", line 562, in relpath
    path_drive, start_drive))
ValueError: path is on mount 'C:', start on mount 'D:'
```

I get an error when I install your module on drive C and load it on drive D.
I changed the `relpath` to `abspath` to use this module.

Thank you.

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
