### PR TITLE
Corrects in-source README links. Replaces master/src with master/pcapkit

### DIFF
--- a/doc/pcap/Frame.md
+++ b/doc/pcap/Frame.md
@@ -27,7 +27,7 @@ typedef struct pcaprec_hdr_s {
 
 ## Extraction
 
- > described in [`src/protocols/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap/frame.py)
+ > described in [`src/protocols/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap/frame.py)
 
 ```python
 class Frame(file, *, num, proto, nanosecond, **kwrags)
@@ -89,7 +89,7 @@ class Frame(file, *, num, proto, nanosecond, **kwrags)
 @staticmethod Frame.decode(byte, *, encoding=None, errors='strict')
 ```
 
- > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol)
+ > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol)
 
  - Positional arguments:
     * `byte` -- `bytes`, byte string to be decoded
@@ -107,7 +107,7 @@ class Frame(file, *, num, proto, nanosecond, **kwrags)
 @staticmethod Frame.unquote(url, *, encoding='utf-8', errors='replace')
 ```
 
- > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol)
+ > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol)
 
  - Positional arguments:
     * `url` -- `str`, URL to be unquoted
@@ -123,7 +123,7 @@ class Frame(file, *, num, proto, nanosecond, **kwrags)
 
 ## Construction
 
- > described in [`src/ipsuite/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite/pcap/frame.py)
+ > described in [`src/ipsuite/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite/pcap/frame.py)
 
 ```python
 class Frame(args, **kwargs)

--- a/doc/pcap/Header.md
+++ b/doc/pcap/Header.md
@@ -41,7 +41,7 @@ typedef struct pcap_hdr_s {
 
 ## Extraction
 
- > described in [`src/protocols/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap/header.py)
+ > described in [`src/protocols/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap/header.py)
 
 ```python
 class Header(file=None, *args, **kwargs)
@@ -97,7 +97,7 @@ class Header(file=None, *args, **kwargs)
 @staticmethod Header.decode(byte, *, encoding=None, errors='strict')
 ```
 
- > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol)
+ > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol)
 
  - Positional arguments:
     * `byte` -- `bytes`, byte string to be decoded
@@ -115,7 +115,7 @@ class Header(file=None, *args, **kwargs)
 @staticmethod Header.unquote(url, *, encoding='utf-8', errors='replace')
 ```
 
- > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol)
+ > cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol)
 
  - Positional arguments:
     * `url` -- `str`, URL to be unquoted
@@ -131,7 +131,7 @@ class Header(file=None, *args, **kwargs)
 
 ## Construction
 
- > described in [`src/ipsuite/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite/pcap/header.py)
+ > described in [`src/ipsuite/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite/pcap/header.py)
 
 ```python
 class Header(args={}, **kwargs)

--- a/pcapkit/README.md
+++ b/pcapkit/README.md
@@ -3,31 +3,31 @@
 &emsp; `pcapkit` is an open source library for PCAP extraction and analysis, written in __Python 3.5__. The following is a manual for this library.
 
  - [Interface](#interface)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#interface-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#interface-manual)
     * [Module Index](#index-interface)
  - [Foundation](#foundation)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#foundation-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#foundation-manual)
     * [Module Index](#index-foundation)
  - [Reassembly](#reassembly)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#reassembly-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#reassembly-manual)
     * [Module Index](#index-reassembly)
  - [IPSuite](#ipsuite)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite#ipsuite-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite#ipsuite-manual)
     * [Module Index](#index-ipsuite)
  - [Protocols](protocols)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocols-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocols-manual)
     * [Module Index](#index-protocols)
  - [Utilities](#utilities)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities#utilities-maunal)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities#utilities-maunal)
     * [Module Index](#index-utilities)
  - [CoreKit](#corekit)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#corekit-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#corekit-manual)
     * [Module Index](#index-corekit)
  - [ToolKit](#toolkit)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#toolkit-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#toolkit-manual)
     * [Module Index](#index-toolkit)
  - [DumpKit](#dumpkit)
-    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit#dumpkit-manual)
+    * [Module Manual](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit#dumpkit-manual)
     * [Module Index](#index-dumpkit)
  - [TODO](#todo)
 
@@ -35,7 +35,7 @@
 
 ## Interface
 
- > described in [`src/interface`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#interfaces-manual)
+ > described in [`src/interface`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#interfaces-manual)
 
 &emsp; Since `pcapkit` has massive classes and numerous functions, `pcapkit.interface` defines several user-oriented interfaces, variables, and etc. These interfaces are designed to help and simplify the usage of `pcapkit`.
 
@@ -45,46 +45,46 @@
 
 | NAME                                                                                        | DESCRIPTION                       |
 | :------------------------------------------------------------------------------------------ | :-------------------------------- |
-| [`extract`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#extract)       | extract a PCAP file               |
-| [`analyse`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#analyse)       | analyse application layer packets |
-| [`reassemble`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#reassemble) | reassemble fragmented datagrams   |
-| [`trace`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#trace)           | trace TCP packet flows            |
+| [`extract`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#extract)       | extract a PCAP file               |
+| [`analyse`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#analyse)       | analyse application layer packets |
+| [`reassemble`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#reassemble) | reassemble fragmented datagrams   |
+| [`trace`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#trace)           | trace TCP packet flows            |
 
 #### Output Formats
 
 | NAME                                                                                | DESCRIPTION                              |
 | :---------------------------------------------------------------------------------- | :--------------------------------------- |
-| [`JSON`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#formats)  | JavaScript Object Notation (JSON) format |
-| [`PLIST`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#formats) | macOS Property LIST (PLIST) format       |
-| [`TREE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#formats)  | Tree-View TeXT (TXT) format              |
-| [`PCAP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#formats)  | Packet CAPture (PCAP) format             |
+| [`JSON`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#formats)  | JavaScript Object Notation (JSON) format |
+| [`PLIST`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#formats) | macOS Property LIST (PLIST) format       |
+| [`TREE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#formats)  | Tree-View TeXT (TXT) format              |
+| [`PCAP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#formats)  | Packet CAPture (PCAP) format             |
 
 #### Layer Thresholds
 
 | NAME                                                                               | DESCRIPTION       |
 | :--------------------------------------------------------------------------------- | :---------------- |
-| [`RAW`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#layers)   | no specific layer |
-| [`LINK`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#layers)  | data-link layer   |
-| [`INET`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#layers)  | internet layer    |
-| [`TRANS`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#layers) | transport layer   |
-| [`APP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#layers)   | application layer |
+| [`RAW`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#layers)   | no specific layer |
+| [`LINK`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#layers)  | data-link layer   |
+| [`INET`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#layers)  | internet layer    |
+| [`TRANS`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#layers) | transport layer   |
+| [`APP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#layers)   | application layer |
 
 #### Extraction Engines
 
 | NAME                                                                                     | DESCRIPTION                                                 |
 | :--------------------------------------------------------------------------------------- | :---------------------------------------------------------- |
-| [`PCAPKit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines)    | the default engine                                          |
-| [`MPServer`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines)   | the multiprocessing engine with server process strategy     |
-| [`MPPipeline`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines) | the multiprocessing engine with pipeline strategy           |
-| [`DPKT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines)       | the [`DPKT`](https://github.com/kbandla/dpkt) engine        |
-| [`Scapy`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines)      | the [`Scapy`](https://scapy.net) engine                     |
-| [`PyShark`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#engines)    | the [`PyShark`](https://kiminewt.github.io/pyshark/) engine |
+| [`PCAPKit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines)    | the default engine                                          |
+| [`MPServer`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines)   | the multiprocessing engine with server process strategy     |
+| [`MPPipeline`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines) | the multiprocessing engine with pipeline strategy           |
+| [`DPKT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines)       | the [`DPKT`](https://github.com/kbandla/dpkt) engine        |
+| [`Scapy`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines)      | the [`Scapy`](https://scapy.net) engine                     |
+| [`PyShark`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#engines)    | the [`PyShark`](https://kiminewt.github.io/pyshark/) engine |
 
 &nbsp;
 
 ## Foundation
 
- > described in [`src/foundation`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#foundation-manual)
+ > described in [`src/foundation`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#foundation-manual)
 
 &emsp; `pcapkit.foundation` is a collection of foundation for `pcapkit`, including PCAP file extraction tool `Extractor`, application layer protocol analyser `analyse` and TCP packet flow tracer `TraceFlow`.
 
@@ -92,15 +92,15 @@
 
 | NAME                                                                                       | DESCRIPTION                          |
 | :----------------------------------------------------------------------------------------- | :----------------------------------- |
-| [`Analysis`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#analysis)   | match protocols & extract attributes |
-| [`Extractor`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#extractor) | extract parameters from a PCAP file  |
-| [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#traceflow) | trace TCP packet flows               |
+| [`Analysis`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#analysis)   | match protocols & extract attributes |
+| [`Extractor`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#extractor) | extract parameters from a PCAP file  |
+| [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#traceflow) | trace TCP packet flows               |
 
 &nbsp;
 
 ## Reassembly
 
- > described in [`src/reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#reassembly-manual)
+ > described in [`src/reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#reassembly-manual)
 
 &emsp; `pcapkit.reassembly` bases on algorithms described in [`RFC 815`](https://tools.ietf.org/html/rfc815), implements datagram reassembly of IP and TCP packets. Currently, it supports reassembly of only 3 different protocols.
 
@@ -108,15 +108,15 @@
 
 | NAME                                                                                                   | DESCRIPTION     |
 | :----------------------------------------------------------------------------------------------------- | :-------------- |
-| [`IPv4_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ipv4_reassembly) | IPv4 Reassembly |
-| [`IPv6_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ipv6_reassembly) | IPv6 Reassembly |
-| [`TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly)   | TCP Reassembly  |
+| [`IPv4_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ipv4_reassembly) | IPv4 Reassembly |
+| [`IPv6_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ipv6_reassembly) | IPv6 Reassembly |
+| [`TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly)   | TCP Reassembly  |
 
 &nbsp;
 
 ## IPSuite
 
- > described in [`src/ipsuite`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite#ipsuite-manual)
+ > described in [`src/ipsuite`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite#ipsuite-manual)
 
 &emsp; `pcapkit.ipsuite` is a collection for protocol constructor described in [Internet Protocol Suite](https://en.wikipedia.org/wiki/Internet_protocol_suite), which is now under construction.
 
@@ -124,14 +124,14 @@
 
 | NAME                                                                                      | DESCRIPTION   |
 | :---------------------------------------------------------------------------------------- | :------------ |
-| [`IPSHeader`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite/pcap#header) | Global Header |
-| [`IPSFrame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/ipsuite/pcap#frame)   | Frame Header  |
+| [`IPSHeader`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite/pcap#header) | Global Header |
+| [`IPSFrame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/ipsuite/pcap#frame)   | Frame Header  |
 
 &nbsp;
 
 ## Protocols
 
- > described in [`src/protocols`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocols-manual)
+ > described in [`src/protocols`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocols-manual)
 
 &emsp; `pcapkit.protocols` is a collection of all protocol families, with detailed implementation and methods. Currently, it includes altogether 22 different protocols and three macro variables.
 
@@ -141,45 +141,45 @@
 
 | NAME                                                                                               | DESCRIPTION                      |
 | :------------------------------------------------------------------------------------------------- | :------------------------------- |
-| [`LINKTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#linktype)       | Link-Layer Header Type Values    |
-| [`ETHERTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ethertype) | EtherType IEEE 802 Numbers       |
-| [`TP_PROTO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#tp_proto)  | Transport Layer Protocol Numbers |
+| [`LINKTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#linktype)       | Link-Layer Header Type Values    |
+| [`ETHERTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ethertype) | EtherType IEEE 802 Numbers       |
+| [`TP_PROTO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#tp_proto)  | Transport Layer Protocol Numbers |
 
 ##### Protocols
 
 | NAME                                                                                                 | DESCRIPTION                         |
 | :--------------------------------------------------------------------------------------------------- | :---------------------------------- |
-| [`Header`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#header)             | Global Header                       |
-| [`Frame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#frame)               | Frame Header                        |
-| [`NoPayload`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#nopayload)            | No-Payload                          |
-| [`Raw`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#raw)                        | Raw Packet Data                     |
-| [`ARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#arp)                   | Address Resolution Protocol         |
-| [`Ethernet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#ethernet)         | Ethernet Protocol                   |
-| [`L2TP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#l2tp)                 | Layer Two Tunnelling Protocol       |
-| [`OSPF`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#ospf)                 | Open Shortest Path First            |
-| [`RARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#rarp)                 | Reverse Address Resolution Protocol |
-| [`VLAN`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#vlan)                 | 802.1Q Customer VLAN Tag Type       |
-| [`AH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ah)                 | Authentication Header               |
-| [`HIP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#hip)               | Host Identity Protocol              |
-| [`HOPOPT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#hopopt)         | IPv6 Hop-by-Hop Options             |
-| [`IP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ip)                 | Internet Protocol                   |
-| [`IPsec`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipsec)           | Internet Protocol Security          |
-| [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv4)             | Internet Protocol version 4         |
-| [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6)             | Internet Protocol version 6         |
-| [`IPv6_Frag`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_frag)   | Fragment Header for IPv6            |
-| [`IPv6_Opts`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_opts)   | Destination Options for IPv6        |
-| [`IPv6_Route`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_route) | Routing Header for IPv6             |
-| [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipx)               | Internetwork Packet Exchange        |
-| [`MH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#mh)                 | Mobility Header                     |
-| [`TCP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#tcp)              | Transmission Control Protocol       |
-| [`UDP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#udp)              | User Datagram Protocol              |
-| [`HTTP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/application#http)          | Hypertext Transfer Protocol         |
+| [`Header`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#header)             | Global Header                       |
+| [`Frame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#frame)               | Frame Header                        |
+| [`NoPayload`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#nopayload)            | No-Payload                          |
+| [`Raw`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#raw)                        | Raw Packet Data                     |
+| [`ARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#arp)                   | Address Resolution Protocol         |
+| [`Ethernet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#ethernet)         | Ethernet Protocol                   |
+| [`L2TP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#l2tp)                 | Layer Two Tunnelling Protocol       |
+| [`OSPF`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#ospf)                 | Open Shortest Path First            |
+| [`RARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#rarp)                 | Reverse Address Resolution Protocol |
+| [`VLAN`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#vlan)                 | 802.1Q Customer VLAN Tag Type       |
+| [`AH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ah)                 | Authentication Header               |
+| [`HIP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#hip)               | Host Identity Protocol              |
+| [`HOPOPT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#hopopt)         | IPv6 Hop-by-Hop Options             |
+| [`IP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ip)                 | Internet Protocol                   |
+| [`IPsec`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipsec)           | Internet Protocol Security          |
+| [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv4)             | Internet Protocol version 4         |
+| [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6)             | Internet Protocol version 6         |
+| [`IPv6_Frag`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_frag)   | Fragment Header for IPv6            |
+| [`IPv6_Opts`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_opts)   | Destination Options for IPv6        |
+| [`IPv6_Route`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_route) | Routing Header for IPv6             |
+| [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipx)               | Internetwork Packet Exchange        |
+| [`MH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#mh)                 | Mobility Header                     |
+| [`TCP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#tcp)              | Transmission Control Protocol       |
+| [`UDP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#udp)              | User Datagram Protocol              |
+| [`HTTP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/application#http)          | Hypertext Transfer Protocol         |
 
 &nbsp;
 
 ## Utilities
 
- > described in [`src/utilities`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities#utilities-manual)
+ > described in [`src/utilities`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities#utilities-manual)
 
 &emsp; `pcapkit.utilities` contains several useful functions and classes which are foundations of `pcapkit`, including decorator function `seekset` and `beholder`, user-refined exceptions and validators.
 
@@ -187,15 +187,15 @@
 
 | NAME                                                                                          | DESCRIPTION                       |
 | :-------------------------------------------------------------------------------------------- | :-------------------------------- |
-| [`decorators`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities#decorators)   | Python decorator functions        |
-| [`validations`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities#validations) | user-defined validation functions |
-| [`exceptions`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities#exceptions)   | user-refined exception classes    |
+| [`decorators`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities#decorators)   | Python decorator functions        |
+| [`validations`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities#validations) | user-defined validation functions |
+| [`exceptions`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities#exceptions)   | user-refined exception classes    |
 
 &nbsp;
 
 ## CoreKit
 
- > described in [`src/corekit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#corekit-manual)
+ > described in [`src/corekit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#corekit-manual)
 
 &emsp; `pcapkit.corekit` is the collection of core utilities for `pcapkit` implementation, including `dict`-like class `Info`, `tuple`-like class `VersionInfo`, and protocol collection class `ProtoChain`.
 
@@ -203,15 +203,15 @@
 
 | NAME                                                                                        | DESCRIPTION               |
 | :------------------------------------------------------------------------------------------ | :------------------------ |
-| [`Info`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#info)               | `dict`-like class         |
-| [`VersionInfo`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#versioninfo) | `tuple`-like class        |
-| [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#protochain)   | protocol collection class |
+| [`Info`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#info)               | `dict`-like class         |
+| [`VersionInfo`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#versioninfo) | `tuple`-like class        |
+| [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#protochain)   | protocol collection class |
 
 &nbsp;
 
 ## ToolKit
 
- > described in [`src/toolkit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#toolkit-manual)
+ > described in [`src/toolkit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#toolkit-manual)
 
 &emsp; `pcapkit.toolkit` is the collections of tools for capability with PCAP extraction engine, such as the default engine, [`Scapy`](https://scapy.net) engine, [`DPKT`](https://github.com/kbandla/dpkt) engine, and [`PyShark`](https://kiminewt.github.io/pyshark/) engine.
 
@@ -221,44 +221,44 @@
 
 | NAME                                                                                                | DESCRIPTION     |
 | :-------------------------------------------------------------------------------------------------- | :-------------- |
-| [`ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#ipv4_reassembly) | IPv4 reassembly |
-| [`ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#ipv6_reassembly) | IPv6 reassembly |
-| [`tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#tcp_reassembly)   | TCP reassembly  |
-| [`tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#tcp_traceflow)     | trace TCP flows |
+| [`ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#ipv4_reassembly) | IPv4 reassembly |
+| [`ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#ipv6_reassembly) | IPv6 reassembly |
+| [`tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#tcp_reassembly)   | TCP reassembly  |
+| [`tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#tcp_traceflow)     | trace TCP flows |
 
 #### [`DPKT`](https://github.com/kbandla/dpkt) Engine
 
 | NAME                                                                                                          | DESCRIPTION                                                                                    |
 | :------------------------------------------------------------------------------------------------------------ | :--------------------------------------------------------------------------------------------- |
-| [`dpkt_ipv6_hdr_len`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_ipv6_hdr_len)       | header length                                                                                  |
-| [`dpkt_packet2chain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_packet2chain)       | make [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#protochain) |
-| [`dpkt_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_packet2dict)         | convert to `dict`                                                                              |
-| [`dpkt_ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_pv4_reassembly)  | IPv4 reassembly                                                                                |
-| [`dpkt_ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_ipv6_reassembly) | IPv6 reassembly                                                                                |
-| [`dpkt_tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_tcp_reassembly)   | TCP reassembly                                                                                 |
-| [`dpkt_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#dpkt_tcp_traceflow)     | trace TCP flows                                                                                |
+| [`dpkt_ipv6_hdr_len`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_ipv6_hdr_len)       | header length                                                                                  |
+| [`dpkt_packet2chain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_packet2chain)       | make [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#protochain) |
+| [`dpkt_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_packet2dict)         | convert to `dict`                                                                              |
+| [`dpkt_ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_pv4_reassembly)  | IPv4 reassembly                                                                                |
+| [`dpkt_ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_ipv6_reassembly) | IPv6 reassembly                                                                                |
+| [`dpkt_tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_tcp_reassembly)   | TCP reassembly                                                                                 |
+| [`dpkt_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#dpkt_tcp_traceflow)     | trace TCP flows                                                                                |
 
 #### [`PyShark`](https://kiminewt.github.io/pyshark/) Engine
 
 | NAME                                                                                                            | DESCRIPTION       |
 | :-------------------------------------------------------------------------------------------------------------- | :---------------- |
-| [`pyshark_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#pyshark_packet2dict)     | convert to `dict` |
-| [`pyshark_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#pyshark_tcp_traceflow) | trace TCP flows   |
+| [`pyshark_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#pyshark_packet2dict)     | convert to `dict` |
+| [`pyshark_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#pyshark_tcp_traceflow) | trace TCP flows   |
 
 #### [`Scapy`](https://scapy.net) Engine
 
 | NAME                                                                                                            | DESCRIPTION                                                                                    |
 | :-------------------------------------------------------------------------------------------------------------- | :--------------------------------------------------------------------------------------------- |
-| [`scapy_packet2chain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_packet2chain)       | make [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit#protochain) |
-| [`scapy_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_packet2dict)         | convert to `dict`                                                                              |
-| [`scapy_ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_pv4_reassembly)  | IPv4 reassembly                                                                                |
-| [`scapy_ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_ipv6_reassembly) | IPv6 reassembly                                                                                |
-| [`scapy_tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_tcp_reassembly)   | TCP reassembly                                                                                 |
-| [`scapy_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit#scapy_tcp_traceflow)     | trace TCP flows                                                                                |
+| [`scapy_packet2chain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_packet2chain)       | make [`ProtoChain`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit#protochain) |
+| [`scapy_packet2dict`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_packet2dict)         | convert to `dict`                                                                              |
+| [`scapy_ipv4_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_pv4_reassembly)  | IPv4 reassembly                                                                                |
+| [`scapy_ipv6_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_ipv6_reassembly) | IPv6 reassembly                                                                                |
+| [`scapy_tcp_reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_tcp_reassembly)   | TCP reassembly                                                                                 |
+| [`scapy_tcp_traceflow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit#scapy_tcp_traceflow)     | trace TCP flows                                                                                |
 
 ## DumpKit
 
- > described in [`src/dumpkit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit#dumpkit-manual)
+ > described in [`src/dumpkit`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit#dumpkit-manual)
 
 &emsp; `pcapkit.dumpkit` is the collection of dumpers for `pcapkit` implementation, which is alike those described in [`dictdumper`](https://github.com/JarryShaw/DictDumper#dictdumper).
 
@@ -266,8 +266,8 @@
 
 | NAME                                                                                                  | DESCRIPTION                  |
 | :---------------------------------------------------------------------------------------------------- | :--------------------------- |
-| [`NotImplementedIO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit#notimplementedio) | NotImplemented I/O simulator |
-| [`PCAP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit#pcap)                         | dump as PCAP file            |
+| [`NotImplementedIO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit#notimplementedio) | NotImplemented I/O simulator |
+| [`PCAP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit#pcap)                         | dump as PCAP file            |
 
 &nbsp;
 

--- a/pcapkit/corekit/README.md
+++ b/pcapkit/corekit/README.md
@@ -10,7 +10,7 @@
 
 ## `Info`
 
- > described in [`src/corekit/infoclass.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit/infoclass.py)
+ > described in [`src/corekit/infoclass.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit/infoclass.py)
 
 ```python
 class Info(builtins.dict)
@@ -38,7 +38,7 @@ class Info(builtins.dict)
 
 ## `VersionInfo`
 
- > described in [`src/corekit/version.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit/version.py)
+ > described in [`src/corekit/version.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit/version.py)
 
 ```python
 class VersionInfo(builtins.tuple)
@@ -58,7 +58,7 @@ class VersionInfo(builtins.tuple)
 
 ## `ProtoChain`
 
- > described in [`src/corekit/protochain.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/corekit/protochain.py)
+ > described in [`src/corekit/protochain.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/corekit/protochain.py)
 
 ```python
 class ProtoChain(builtins.object)

--- a/pcapkit/dumpkit/README.md
+++ b/pcapkit/dumpkit/README.md
@@ -9,7 +9,7 @@
 
 ## `PCAP`
 
- > decribed in [`src/dumpkit/__init.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit/__init__.py)
+ > decribed in [`src/dumpkit/__init.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit/__init__.py)
 
 ```python
 class PCAP(builtins.object)
@@ -37,7 +37,7 @@ class PCAP(builtins.object)
 
 ## `NotImplementedIO`
 
- > decribed in [`src/dumpkit/__init.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/dumpkit/__init__.py)
+ > decribed in [`src/dumpkit/__init.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/dumpkit/__init__.py)
 
 ```python
 class NotImplementedIO(builtins.object)

--- a/pcapkit/foundation/README.md
+++ b/pcapkit/foundation/README.md
@@ -3,21 +3,21 @@
 &emsp; `pcapkit` is an open source library for PCAP extraction and analysis, written in __Python 3.6__. The following is a manual for fundamental tools in the library.
 
  - [Extraction](#extraction)
-    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation/extraction.py)
+    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation/extraction.py)
     * [`Extractor`](#extractor)
  - [Analysis](#analysis)
-    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation/analysis.py)
+    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation/analysis.py)
     * [`analyse`](#analyse)
     * [`Analysis`](#class-analysis)
  - [Trace TCP Flows](#traceflow)
-    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation/traceflow.py)
+    * [Reference](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation/traceflow.py)
     * [`TraceFlow`](#class-traceflow)
 
 ---
 
 ## Extraction
 
- > described in [`src/foundation/extraction.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation/extraction.py)
+ > described in [`src/foundation/extraction.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation/extraction.py)
 
 &emsp; `pcapkit.foundation.extraction` contains `Extractor` only, which synthesises file I/O and protocol analysis, coordinates information exchange in all network layers, extract parameters from a PCAP file.
 
@@ -110,7 +110,7 @@ class Extractor(builtins.object)
 
 ## Analysis
 
- > described in [`src/foundation/analysis.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation/analysis.py)
+ > described in [`src/foundation/analysis.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation/analysis.py)
 
 &emsp; `pcapkit.foundation.analysis` works as a header quarter to analyse and match application layer protocol. Then, call corresponding modules and functions to extract the attributes.
 
@@ -148,7 +148,7 @@ class Analysis(builtins.object)
 
 ## Trace TCP Flows
 
- > described in [`src/foundation/traceflow.py`](https://github.com/JarryShaw/pypcaokit/tree/master/src/foundation/traceflow.py)
+ > described in [`src/foundation/traceflow.py`](https://github.com/JarryShaw/pypcaokit/tree/master/pcapkit/foundation/traceflow.py)
 
 &emsp; `pcapkit.foundation.traceflow` is the interface to trace TCP flows from a series of packets and connections. This was implemented as the demand of my mate @gousaiyang.
 

--- a/pcapkit/interface/README.md
+++ b/pcapkit/interface/README.md
@@ -87,7 +87,7 @@ extract(*,
     | `trace_format` | `str`  | `None`  | `plist` / `json` / `tree` / `html` / `pcap` / `None`            | output format of flow tracer                            |
 
  - Returns:
-    * `Extractor` -- an Extractor object form [`pcapkit.foundation.extraction`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#extraction)
+    * `Extractor` -- an Extractor object form [`pcapkit.foundation.extraction`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#extraction)
 
 &nbsp;
 
@@ -104,7 +104,7 @@ analyse(*, file, length=None)
     * `length` -- `int`, length of the analysing packet
 
  - Returns:
-    * `Analysis` -- an `Analysis` object from [`pcapkit.foundation.analysis`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#analysis)
+    * `Analysis` -- an `Analysis` object from [`pcapkit.foundation.analysis`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#analysis)
 
 &nbsp;
 
@@ -124,9 +124,9 @@ reassemble(*, protocol, strict=False)
     | `strict`   | `bool` | `False` | `True` / `False`        | if return all datagrams (including those not implemented) when submit |
 
  - Returns:
-    * *if protocol is IPv4* `IPv4_Reassembly` -- a `IPv4_Reassembly` object from [`pcapkit.reassembly.ipv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ipv4_reassembly)
-    * *if protocol is IPv6* `IPv6_Reassembly` -- a` IPv6_Reassembly` object from [`pcapkit.reassembly.ipv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ipv6_reassembly)
-    * *if protocol is TCP* `TCP_Reassembly` -- a `TCP_Reassembly` object from [`pcapkit.reassembly.tcp`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly)
+    * *if protocol is IPv4* `IPv4_Reassembly` -- a `IPv4_Reassembly` object from [`pcapkit.reassembly.ipv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ipv4_reassembly)
+    * *if protocol is IPv6* `IPv6_Reassembly` -- a` IPv6_Reassembly` object from [`pcapkit.reassembly.ipv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ipv6_reassembly)
+    * *if protocol is TCP* `TCP_Reassembly` -- a `TCP_Reassembly` object from [`pcapkit.reassembly.tcp`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly)
 
 &nbsp;
 
@@ -143,4 +143,4 @@ trace(*, fout=None, format=None)
     * `format` -- `str`, output format
 
  - Returns:
-    * `TraceFlow` -- a [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#class-traceflow) object
+    * `TraceFlow` -- a [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#class-traceflow) object

--- a/pcapkit/protocols/README.md
+++ b/pcapkit/protocols/README.md
@@ -7,17 +7,17 @@
  - [Utility Protocols](#utility-protocols)
     * [`Raw`](#raw)
     * [`NoPayload`](#nopayload)
-    * [PCAP](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#pcap-headers-manual)
- - [Link Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#link-layer-protocols-manual)
+    * [PCAP](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#pcap-headers-manual)
+ - [Link Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#link-layer-protocols-manual)
     * [Macros](#link-macros)
     * [Protocols](#link-protocols)
- - [Internet Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#internet-layer-protocols-manual)
+ - [Internet Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#internet-layer-protocols-manual)
     * [Macros](#internet-macros)
     * [Protocols](#internet-protocols)
- - [Transport Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#transport-layer-protocols-manual)
+ - [Transport Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#transport-layer-protocols-manual)
     * [Macros](#transport-macros)
     * [Protocols](#transport-protocols)
- - [Application Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/application#application-layer-protocols-manual)
+ - [Application Layer Protocols](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/application#application-layer-protocols-manual)
     * [Protocols](#application-protocols)
  - [TODO](#todo)
 
@@ -25,7 +25,7 @@
 
 ## Base Protocol
 
- > described in [src/protocols/protocol.py](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/protocol.py)
+ > described in [src/protocols/protocol.py](https://gihub.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/protocol.py)
 
 &emsp; `pcapkit.protocols.protocol` contains [`Protocol`](#protocol) only, which is an abstract base clss for all protocol family, with pre-defined utility arguments and methods of specified protocols.
 
@@ -160,7 +160,7 @@ class Protocol(builtins.object)
 
 ### `Raw`
 
-> described in [`src/protocols/raw.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/raw.py)
+> described in [`src/protocols/raw.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/raw.py)
 
 &emsp; `pcapkit.protocols.raw` contains `Raw` only, which implements extractor for unknown protocol, and constructs a [`Protocol`](#protocol) like object.
 
@@ -182,8 +182,8 @@ class Raw(pcapkit.protocols.protocol.Protocol)
     * `protochain` -- `ProtoChain`, protocol chain of current instance
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_raw` -- read raw packet data
 
  - Data modules:
@@ -200,7 +200,7 @@ class Raw(pcapkit.protocols.protocol.Protocol)
 
 ### `NoPayload`
 
-> described in [`src/protocols/null.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/null.py)
+> described in [`src/protocols/null.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/null.py)
 
 &emsp; `pcapkit.protocols.null` contains `NoPayload` only, which implements a [`Protocol`](#protocol) like object whose payload is recursively `NoPayload` itself.
 
@@ -217,23 +217,23 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
     * `protochain` -- `NotImplemented`, protocol chain (not implemented)
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
 
  - Data modules:
     * all data modules inherited from [`Protocol`](#protocol)
 
 ### PCAP
 
- > described in [`src/protocols/pcap`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#pcap-headers-manual)
+ > described in [`src/protocols/pcap`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#pcap-headers-manual)
 
-&emsp; `pcapkit.protocols.pcap` contains header descriptions for PCAP files, including global header [`Header`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#header) and frame header [`Frame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap#frame).
+&emsp; `pcapkit.protocols.pcap` contains header descriptions for PCAP files, including global header [`Header`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#header) and frame header [`Frame`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap#frame).
 
 &emsp;
 
 ## Link Layer Protocols
 
- > described in [`src/protocols/link`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#link-layer-protocols-manual)
+ > described in [`src/protocols/link`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#link-layer-protocols-manual)
 
 &emsp; `pcapkit.protocols.link` is collection of all protocols in link layer, with detailed implementation and methods.
 
@@ -241,7 +241,7 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 ### Macros
 
- - [`LINKTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#linktype) -- Link-Layer Header Type Values
+ - [`LINKTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#linktype) -- Link-Layer Header Type Values
 
 <a name="link-protocols"> </a>
 
@@ -249,16 +249,16 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 | NAME                                                                                         | DESCRIPTION                         |
 | :------------------------------------------------------------------------------------------- | :---------------------------------- |
-| [`ARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#arp)           | Address Resolution Protocol         |
-| [`Ethernet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#ethernet) | Ethernet Protocol                   |
-| [`L2TP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#l2tp)         | Layer Two Tunneling Protocol        |
-| [`OSPF`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#ospf)         | Open Shortest Path First            |
-| [`RARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#rarp)         | Reverse Address Resolution Protocol |
-| [`VLAN`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link#vlan)         | 802.1Q Customer VLAN Tag Type       |
+| [`ARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#arp)           | Address Resolution Protocol         |
+| [`Ethernet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#ethernet) | Ethernet Protocol                   |
+| [`L2TP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#l2tp)         | Layer Two Tunneling Protocol        |
+| [`OSPF`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#ospf)         | Open Shortest Path First            |
+| [`RARP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#rarp)         | Reverse Address Resolution Protocol |
+| [`VLAN`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link#vlan)         | 802.1Q Customer VLAN Tag Type       |
 
 ## Internet Layer Protocols
 
- > described in [`src/protocols/internet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#internet-layer-protocols-manual)
+ > described in [`src/protocols/internet`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#internet-layer-protocols-manual)
 
 &emsp; `pcapkit.protocols.internet` is collection of all protocols in internet layer, with detailed implementation and methods.
 
@@ -266,7 +266,7 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 ### Macros
 
- - [`ETHERTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ethertype) -- Ethertype IEEE 802 Numbers
+ - [`ETHERTYPE`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ethertype) -- Ethertype IEEE 802 Numbers
 
 <a name="internet-protocols"> </a>
 
@@ -274,22 +274,22 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 | NAME                                                                                                 | DESCRIPTION                  |
 | :--------------------------------------------------------------------------------------------------- | :--------------------------- |
-| [`AH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ah)                 | Athentication Header         |
-| [`HIP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#hip)               | Host Identity Protocol       |
-| [`HOPOPT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#hopopt)         | IPv6 Hop-by-Hop Options      |
-| [`IP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ip)                 | Internet Protocol            |
-| [`IPsec`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipsec)           | Internet Protocol Security   |
-| [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv4)             | Internet Protocol version 4  |
-| [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6)             | Internet Protocol version 6  |
-| [`IPv6_Frag`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_frag)   | Fragment Header for IPv6     |
-| [`IPv6_Opts`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_opts)   | Destination Options for IPv6 |
-| [`IPv6_Route`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6_route) | Routing Header for IPv6      |
-| [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipx)               | Internetwork Packet Exchange |
-| [`MH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#mh)                 | Mobility Header              |
+| [`AH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ah)                 | Athentication Header         |
+| [`HIP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#hip)               | Host Identity Protocol       |
+| [`HOPOPT`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#hopopt)         | IPv6 Hop-by-Hop Options      |
+| [`IP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ip)                 | Internet Protocol            |
+| [`IPsec`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipsec)           | Internet Protocol Security   |
+| [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv4)             | Internet Protocol version 4  |
+| [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6)             | Internet Protocol version 6  |
+| [`IPv6_Frag`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_frag)   | Fragment Header for IPv6     |
+| [`IPv6_Opts`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_opts)   | Destination Options for IPv6 |
+| [`IPv6_Route`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6_route) | Routing Header for IPv6      |
+| [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipx)               | Internetwork Packet Exchange |
+| [`MH`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#mh)                 | Mobility Header              |
 
 ## Transport Layer Protocols
 
- > described in [`src/protocols/transport`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#transport-layer-protocols-manual)
+ > described in [`src/protocols/transport`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#transport-layer-protocols-manual)
 
 &emsp; `pcapkit.protocols.transport` is collection of all protocols in transport layer, with detailed implementation and methods.
 
@@ -297,7 +297,7 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 ### Macros
 
- - [`TP_PROTO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#tp_proto) -- Transport Layer Protocol Numbers
+ - [`TP_PROTO`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#tp_proto) -- Transport Layer Protocol Numbers
 
 <a name="transport-protocols"> </a>
 
@@ -305,13 +305,13 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 | NAME                                                                                    | DESCRIPTION                   |
 | :-------------------------------------------------------------------------------------- | :---------------------------- |
-| [`TCP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#tcp) | Transmission Control Protocol |
-| [`UDP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/transport#udp) | User Datagram Protocol        |
+| [`TCP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#tcp) | Transmission Control Protocol |
+| [`UDP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/transport#udp) | User Datagram Protocol        |
 
 
 ## Application Layer Protocols
 
- > described in [`src/protocols/application`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/application#application-layer-protocols-manual)
+ > described in [`src/protocols/application`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/application#application-layer-protocols-manual)
 
 &emsp; `pcapkit.protocols.application` is collection of all protocols in application layer, with detailed implementation and methods.
 
@@ -321,7 +321,7 @@ class NoPayload(pcapkit.protocols.protocol.Protocol)
 
 | NAME                                                                                        | DESCRIPTION                 |
 | :------------------------------------------------------------------------------------------ | :-------------------------- |
-| [`HTTP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/application#http) | Hypertext Transfer Protocol |
+| [`HTTP`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/application#http) | Hypertext Transfer Protocol |
 
 ## TODO
 

--- a/pcapkit/protocols/link/README.md
+++ b/pcapkit/protocols/link/README.md
@@ -15,7 +15,7 @@
 
 ## `Link`
 
- > described in [`src/protocols/link/link.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/link.py)
+ > described in [`src/protocols/link/link.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/link.py)
 
 ```python
 class Link(pcapkit.protocols.protocol.Protocol)
@@ -51,11 +51,11 @@ class Link(pcapkit.protocols.protocol.Protocol)
                 - [`ARP`](#arp) -- Address Resolution Protocol
                 - [`RARP`](#rarp) -- Reversed Address Resolution Protocol
                 - [`VLAN`](#vlan) -- 802.1Q Customer VLAN Tag Type
-            * [Internet Layer](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#internet-layer-protocols-manual):
-                - [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv4) -- Internet Protocol version 4
-                - [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6) -- Internet Protocol version 6
-                - [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipx) -- Internetwork Protocol Exchange
-    * all other utility functions inherited from [`Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol)
+            * [Internet Layer](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#internet-layer-protocols-manual):
+                - [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv4) -- Internet Protocol version 4
+                - [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6) -- Internet Protocol version 6
+                - [`IPX`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipx) -- Internetwork Protocol Exchange
+    * all other utility functions inherited from [`Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol)
 
 ### `LINKTYPE`
 
@@ -68,13 +68,13 @@ class Link(pcapkit.protocols.protocol.Protocol)
 | `0`   | `Null`                                                                                   | BSD loopback encapsulation |
 | `1`   | [`Ethernet`](#ethernet)                                                                  | IEEE 802.3 Ethernet        |
 | `101` | `Raw`                                                                                    | Raw IP                     |
-| `228` | [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv4) | Raw IPv4                   |
-| `229` | [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/internet#ipv6) | Raw IPv6                   |
+| `228` | [`IPv4`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv4) | Raw IPv4                   |
+| `229` | [`IPv6`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/internet#ipv6) | Raw IPv6                   |
 | `248` | `SCTP`                                                                                   | SCTP packets               |
 
 ## `ARP`
 
- > described in [`src/protocols/link/arp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/arp.py)
+ > described in [`src/protocols/link/arp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/arp.py)
 
 ```python
 class ARP(pcapkit.protocols.link.link.Link)
@@ -114,13 +114,13 @@ class ARP(pcapkit.protocols.link.link.Link)
     * `type` -- `tuple<str, str>`, hardware & protocol type
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_arp` -- read Address Resolution Protocol
 
 ## `Ethernet`
 
- > described in [`src/protocols/link/ethernet.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/ethernet.py)
+ > described in [`src/protocols/link/ethernet.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/ethernet.py)
 
 ```python
 class Ethernet(pcapkit.protocols.link.link.Link)
@@ -146,13 +146,13 @@ class Ethernet(pcapkit.protocols.link.link.Link)
     * `dst` -- `str`, source MAC address
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_ethernet` -- read Ethernet Protocol
 
 ## `L2TP`
 
- > described in [`src/protocols/link/l2tp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/l2tp.py)
+ > described in [`src/protocols/link/l2tp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/l2tp.py)
 
 ```python
 class L2TP(pcapkit.protocols.link.link.Link)
@@ -187,13 +187,13 @@ class L2TP(pcapkit.protocols.link.link.Link)
     * `type` -- `str`, L2TP type
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * read_l2tp -- read Layer Two Tunnelling Protocol
 
 ## `OSPF`
 
- > described in [`src/protocols/link/ospf.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/ospf.py)
+ > described in [`src/protocols/link/ospf.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/ospf.py)
 
 ```python
 class OSPF(pcapkit.protocols.link.link.Link)
@@ -226,13 +226,13 @@ class OSPF(pcapkit.protocols.link.link.Link)
     * `type` -- `str`, OSPF packet type
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_ospf` -- read Open Shortest Path First
 
 ## `RARP`
 
- > described in [`src/protocols/link/rarp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/rarp.py)
+ > described in [`src/protocols/link/rarp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/rarp.py)
 
 ```python
 class RARP(pcapkit.protocols.link.arp.ARP)
@@ -270,13 +270,13 @@ class RARP(pcapkit.protocols.link.arp.ARP)
     * `type` -- `tuple<str, str>`, hardware & protocol type
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_arp` -- read Address Resolution Protocol
 
 ## `VLAN`
 
- > described in [`src/protocols/link/vlan.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/link/vlan.py)
+ > described in [`src/protocols/link/vlan.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/link/vlan.py)
 
 ```python
 class VLAN(pcapkit.protocols.link.link.Link)
@@ -302,6 +302,6 @@ class VLAN(pcapkit.protocols.link.link.Link)
     * `protochain` -- `ProtoChain`, protocol chain of current instance
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
     * `read_vlan` -- read 802.1Q Customer VLAN Tag Type

--- a/pcapkit/protocols/pcap/README.md
+++ b/pcapkit/protocols/pcap/README.md
@@ -9,7 +9,7 @@
 
 ## `Header`
 
- > described in [`src/protocols/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap/header.py)
+ > described in [`src/protocols/pcap/header.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap/header.py)
 
 &emsp; `pcapkit.protocols.pcap.header` contains `Header` only, which implements extractor for global headers of PCAP.
 
@@ -38,9 +38,9 @@ class Header(pcapkit.protocols.protocol.Protocol)
     * `protocol` -- `str`, data link type
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `index` -- call [`ProtoChain.index`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src#protochain)
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `index` -- call [`ProtoChain.index`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit#protochain)
     * `read_header` -- read global header of PCAP file
 
  - Data modules:
@@ -56,7 +56,7 @@ class Header(pcapkit.protocols.protocol.Protocol)
 
 ## `Frame`
 
- > described in [`src/protocols/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols/pcap/frame.py)
+ > described in [`src/protocols/pcap/frame.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols/pcap/frame.py)
 
 &emsp; `pcapkit.protocols.pcap.frame` contains `Frame` only, which implements extractor for frame headers of PCAP.
 
@@ -88,9 +88,9 @@ class Frame(pcapkit.protocols.protocol.Protocol)
     * `protochain` -- `ProtoChain`, protocol chain of current frame
 
  - Methods:
-    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/protocols#protocol))
-    * `index` -- call [`ProtoChain.index`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src#protochain)
+    * `decode_bytes` -- try to decode `bytes` into `str` (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `decode_url` -- decode URLs into Unicode (cf. [`pcapkit.protocols.protocol.Protocol`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/protocols#protocol))
+    * `index` -- call [`ProtoChain.index`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit#protochain)
     * `read_header` -- read each block after global header
 
  - Data modules:

--- a/pcapkit/reassembly/README.md
+++ b/pcapkit/reassembly/README.md
@@ -110,7 +110,7 @@ timer expires: {
 
 ### `Reassembly`
 
- > described in [`src/reassembly/reassembly.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly/reassembly.py)
+ > described in [`src/reassembly/reassembly.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly/reassembly.py)
 
 &emsp; `pcapkit.reassembly.reassembly` contains `Reassembly` only, which is an abstract base class for all reassembly classes, bases on algorithms described in [`RFC 815`](https://tools.ietf.org/html/rfc815), implements datagram reassembly of IP and TCP packets.
 
@@ -175,7 +175,7 @@ class Reassembly(builtins.object)
 
 ### `IP_Reassembly`
 
- > described in [`src/reassembly/ip.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly/ip.py)
+ > described in [`src/reassembly/ip.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly/ip.py)
 
 &emsp; `pcapkit.reassembly.ip` contains `IP_Reassembly` only, which is the base class for IPv4 and IPv6 reassembly. The algorithm implementation is based on IP reassembly procedure introduced in [`RFC 791`](https://tools.ietf.org/html/rfc791), using `RCVBT` (fragment received-bit table). Though another algorithm is explained in [`RFC 815`](https://tools.ietf.org/html/rfc815), replacing `RCVBT`, however, this implementation still used the elder one.
 
@@ -273,7 +273,7 @@ class IP_Reassembly(pcapkit.reassembly.reassembly.Reassembly)
 
 #### `IPv4_Reassembly`
 
- > described in [`src/reassembly/ipv4.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly/ipv4.py)
+ > described in [`src/reassembly/ipv4.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly/ipv4.py)
 
 ```python
 class IPv4_Reassembly(pcapkit.reassembly.ip.IP_Reassembly)
@@ -294,7 +294,7 @@ class IPv4_Reassembly(pcapkit.reassembly.ip.IP_Reassembly)
 
 #### `IPv6_Reassembly`
 
- > described in [`src/reassembly/ipv6.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly/ipv6.py)
+ > described in [`src/reassembly/ipv6.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly/ipv6.py)
 
 ```python
 class IPv6_Reassembly(pcapkit.reassembly.ip.IP_Reassembly)
@@ -315,7 +315,7 @@ class IPv6_Reassembly(pcapkit.reassembly.ip.IP_Reassembly)
 
 ### `TCP_Reassembly`
 
- > described in [`src/reassembly/tcp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly/tcp.py)
+ > described in [`src/reassembly/tcp.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly/tcp.py)
 
 &emsp; `pcapkit.reassembly.tcp` contains `TCP_Reassembly` only, which reconstructs fragmented TCP packets back to origin. The algorithm implementation is based on `IP Datagram Reassembly Algorithm` introduced in [`RFC 815`](https://tools.ietf.org/html/rfc815). It described an algorithm dealing with `RCVBT` (fragment received bit table) appeared in [`RFC 791`](https://tools.ietf.org/html/rfc791).
 

--- a/pcapkit/toolkit/README.md
+++ b/pcapkit/toolkit/README.md
@@ -36,7 +36,7 @@
 
 ## PyPCAPKit
 
- > described in [`src/toolkit/default.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit/default.py)
+ > described in [`src/toolkit/default.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit/default.py)
 
 &emsp; `pcapkit.toolkit.default` contains all you need for `PyPCAPKit` handy usage. All functions returns with a flag to indicate if usable for its caller.
 
@@ -53,11 +53,11 @@ ipv4_reassembly(frame)
 ##### Make data for IPv4 reassembly.
 
  - Positional arguments:
-    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/src/protocols/pcap#frame) object
+    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/protocols/pcap#frame) object
 
  - Returns:
     * `bool` -- flag if `frame` is usable for IPv4 reassembly
-    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="ipv6_reassembly"> </a>
@@ -71,11 +71,11 @@ ipv6_reassembly(frame)
 ##### Make data for IPv6 reassembly.
 
  - Positional arguments:
-    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/src/protocols/pcap#frame) object
+    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/protocols/pcap#frame) object
 
  - Returns:
     * `bool` -- flag if `frame` is usable for IPv6 reassembly
-    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="tcp_reassembly"> </a>
@@ -89,11 +89,11 @@ tcp_reassembly(frame)
 ##### Make data for TCP reassembly.
 
  - Positional arguments:
-    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/src/protocols/pcap#frame) object
+    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/protocols/pcap#frame) object
 
  - Returns:
     * `bool` -- flag if `frame` is usable for TCP reassembly
-    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly)
+    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly)
     * *if `False`* `None`
 
 <a name="tcp_traceflow"> </a>
@@ -107,21 +107,21 @@ tcp_traceflow(frame, *, data_link)
 ##### Trace packet flow for TCP.
 
  - Positional arguments:
-    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/src/protocols/pcap#frame) object
+    * `frame` -- `Frame`, a [`pcapkit.protocols.pcap.frame.Frame`](https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/protocols/pcap#frame) object
 
  - Keyword arguments:
     * `data_link` -- `str`, name of data link layer protocol
 
  - Returns:
     * `bool` -- flag if `frame` is usable for tracing TCP flows
-    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/src/foundation#class-traceflow)
+    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/foundation#class-traceflow)
     * *if `False`* `None`
 
 &nbsp;
 
 ## DPKT
 
- > described in [`src/toolkit/dpkt.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit/dpkt.py)
+ > described in [`src/toolkit/dpkt.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit/dpkt.py)
 
 &emsp; `pcapkit.toolkit.dpkt` contains all you need for [`PyPCAPKit`](https://github.com/JarryShaw/pypcapkit#pypcapkit) handy usage with [`DPKT`](https://github.com/kbandla/dpkt) engine. All reforming functions returns with a flag to indicate if usable for its caller.
 
@@ -205,7 +205,7 @@ ipv4_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for IPv4 reassembly
-    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="dpkt_ipv6_reassembly"> </a>
@@ -226,7 +226,7 @@ ipv6_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for IPv6 reassembly
-    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="dpkt_tcp_reassembly"> </a>
@@ -247,7 +247,7 @@ tcp_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for TCP reassembly
-    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly)
+    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly)
     * *if `False`* `None`
 
 <a name="dpkt_tcp_traceflow"> </a>
@@ -270,14 +270,14 @@ tcp_traceflow(packet, timestamp, *, data_link, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for tracing TCP flows
-    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/src/foundation#class-traceflow)
+    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/foundation#class-traceflow)
     * *if `False`* `None`
 
 &nbsp;
 
 ## PyShark
 
- > described in [`src/toolkit/pyshark.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit/pyshark.py)
+ > described in [`src/toolkit/pyshark.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit/pyshark.py)
 
 &emsp; `pcapkit.toolkit.pyshark` contains all you need for [`PyPCAPKit`](https://github.com/JarryShaw/pypcapkit#pypcapkit) handy usage with [`PyShark`](https://kiminewt.github.io/pyshark/) engine. All reforming functions returns with a flag to indicate if usable for its caller.
 
@@ -318,14 +318,14 @@ tcp_traceflow(packet)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for tracing TCP flows
-    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/src/foundation#class-traceflow)
+    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/foundation#class-traceflow)
     * *if `False`* `None`
 
 &nbsp;
 
 ## Scapy
 
- > described in [`src/toolkit/scapy.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/toolkit/scapy.py)
+ > described in [`src/toolkit/scapy.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/toolkit/scapy.py)
 
 &emsp; `pcapkit.toolkit.scapy` contains all you need for [`PyPCAPKit`](https://github.com/JarryShaw/pypcapkit#pypcapkit) handy usage with [`Scapy`](https://scapy.net) engine. All reforming functions returns with a flag to indicate if usable for its caller.
 
@@ -390,7 +390,7 @@ ipv4_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for IPv4 reassembly
-    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv4 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="scapy_ipv6_reassembly"> </a>
@@ -411,7 +411,7 @@ ipv6_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for IPv6 reassembly
-    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly)
+    * *if `True`* `dict` -- data for IPv6 reassembly as described in [`pcapkit.reassembly.ip.IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly)
     * *if `False`* `None`
 
 <a name="scapy_tcp_reassembly"> </a>
@@ -432,7 +432,7 @@ tcp_reassembly(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for TCP reassembly
-    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly)
+    * *if `True`* `dict` -- data for TCP reassembly as described in [`pcapkit.reassembly.tcp.TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly)
     * *if `False`* `None`
 
 <a name="scapy_tcp_traceflow"> </a>
@@ -453,5 +453,5 @@ tcp_traceflow(packet, *, count=NotImplemented)
 
  - Returns:
     * `bool` -- flag if `packet` is usable for tracing TCP flows
-    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/src/foundation#class-traceflow)
+    * *if `True`* `dict` -- data for tracing TCP flows as descibed in [`pcapkit.foundation.traceflow.TraceFlow`](#https://github.com/JarryShaw/pcapkit/tree/master/pcapkit/foundation#class-traceflow)
     * *if `False`* `None`

--- a/pcapkit/utilities/README.md
+++ b/pcapkit/utilities/README.md
@@ -21,7 +21,7 @@
 
 ## Decorators
 
- > described in [`src/utilities/decorators.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities/decorators.py)
+ > described in [`src/utilities/decorators.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities/decorators.py)
 
 &emsp; `pcapkit.utilities.decorators` contains several useful decorators, including `seekset` and `beholder`.
 
@@ -83,7 +83,7 @@ __NOTE__: positional argument `file` in `behold` must be a *file-like* object.
 
 ## Validations
 
- > described in [`src/utilities/validations.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities/validations.py)
+ > described in [`src/utilities/validations.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities/validations.py)
 
 &emsp; `pcapkit.utilities.validations` contains functions to validate arguments for functions and classes. It first appears in
 [`ntlib`](https://github.com/JarryShaw/pyntlib) as validators.
@@ -123,7 +123,7 @@ type_check(*agrs, func=None)
 pkt_check(*args, func=None)
 ```
 
-&emsp; `pkt_check` is the validator for `TraceFlow`. For more information on packet format, please refer to the documentation of [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/foundation#traceflow).
+&emsp; `pkt_check` is the validator for `TraceFlow`. For more information on packet format, please refer to the documentation of [`TraceFlow`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/foundation#traceflow).
 
 ```python
 frag_check(*args, protocol, func=None)
@@ -131,13 +131,13 @@ _ip_frag_check(*args, func=None)
 _tcp_frag_check(*args, func=None)
 ```
 
-&emsp; As for `frag_check`, `str` type keyword argument `protocol` indicates what protocol the fragment is reassembled for, which must be either `IP` (`IPv4` & `IPv6`) or `TCP`. Then, `_ip_frag_check` or `_tcp_frag_check` shall be called to validate arguments caller passed into. For more information on fragment format, please refer to the documentation of [`IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#ip_reassembly) and [`TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/reassembly#tcp_reassembly).
+&emsp; As for `frag_check`, `str` type keyword argument `protocol` indicates what protocol the fragment is reassembled for, which must be either `IP` (`IPv4` & `IPv6`) or `TCP`. Then, `_ip_frag_check` or `_tcp_frag_check` shall be called to validate arguments caller passed into. For more information on fragment format, please refer to the documentation of [`IP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#ip_reassembly) and [`TCP_Reassembly`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/reassembly#tcp_reassembly).
 
 &nbsp;
 
 ## Exceptions
 
- > described in [`src/utilities/exceptions.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities/exceptions.py)
+ > described in [`src/utilities/exceptions.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities/exceptions.py)
 
 &emsp; `pcapkit.utilities.exceptions` refined built-in exceptions. Make it possible to show only user error stack information, when exception raised on user's operation.
 
@@ -204,7 +204,7 @@ class error(pcapkit.utilities.exceptions.BaseError, builtins.Exception)
 
 ## Warnings
 
-> described in [`src/utilities/warnings.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/utilities/warnings.py)
+> described in [`src/utilities/warnings.py`](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/utilities/warnings.py)
 
 &emsp; `pcapkit.utilities.warnings` refined built-in warnings.
 


### PR DESCRIPTION
## Please follow the guide below

- [x] [Searched](https://github.com/JarryShaw/PyPCAPKit/search?q=is%3Apr&type=Issues) for similar pull requests
- [ ] ~~Followed PEP8 coding style~~ Not applicable
- [x] Tested with proper test samples

### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature

---

### Description of your *pull request* and other information

This pull request broken links to the code in the `README` files of the `master/pcapkit` and `master/doc` directories.  Extension of #36 .

* Before PR: in any README of `master/pcapkit` or `master/doc` targeting the sources or other README (for example [pcapkit/README#interface](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit#interface)), clicking on any link (`extract`, `analyse` ...) redirects to [https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#extract](https://github.com/JarryShaw/PyPCAPKit/tree/master/src/interface#extract) instead of [https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#extract](https://github.com/JarryShaw/PyPCAPKit/tree/master/pcapkit/interface#extract)
* After PR: all the links now correctely redirect to the `master/pcapkit` appropriate file.  (Thanks `sed` !)

