### PR TITLE
Prevent maintenance workflow push races

### DIFF
--- a/.github/workflows/cron-conda.yml
+++ b/.github/workflows/cron-conda.yml
@@ -10,6 +10,9 @@ jobs:
   conda-update:
     name: Update requirements.txt
     runs-on: ubuntu-latest
+    concurrency:
+      group: repository-maintenance
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -61,6 +64,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+          pull: rebase
 
       - name: Get Version
         if: steps.verify-changed-files.outputs.files_changed == 'true'

--- a/.github/workflows/cron-vendor.yml
+++ b/.github/workflows/cron-vendor.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   vendor-update:
     runs-on: macos-latest
+    concurrency:
+      group: repository-maintenance
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -66,6 +69,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+          pull: rebase
 
       # - name: Create Tag
       #   if: steps.verify-changed-files.outputs.files_changed == 'true'


### PR DESCRIPTION
## Summary

- serialize the Conda and Vendor maintenance writer jobs with a shared concurrency group
- rebase generated commits onto the latest main branch before pushing
- prevent the fetch-first rejection observed in Vendor Update run 32527152872

## Verification

- inspected the failed job log and confirmed Conda Update advanced main during Vendor Update
- validated all workflow YAML files locally
- checked the patch with git diff --check